### PR TITLE
feat: use Rspack instead of Webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35184,7 +35184,7 @@
       }
     },
     "packages/ember-auto-import": {
-      "version": "2.6.3",
+      "version": "2.6.3-vero-fork",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-auto-import",
-  "version": "2.6.3",
+  "version": "2.6.3-vero-fork",
   "description": "Zero-config import from NPM packages",
   "keywords": [
     "ember-addon",

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -123,17 +123,17 @@ export default class AutoImport implements AutoImportSharedAPI {
     });
 
     let webpack: typeof webpackType;
-    const pkg = resolvePackagePath('webpack', this.rootPackage.root);
+    const pkg = resolvePackagePath('@rspack/core', this.rootPackage.root);
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    if (pkg && semver.satisfies(require(pkg).version, '^5.0.0')) {
+    if (pkg && semver.satisfies(require(pkg).version, '^1.2.7')) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      webpack = require(resolve.sync('webpack', {
+      webpack = require(resolve.sync('@rspack/core', {
         basedir: this.rootPackage.root,
-      })) as typeof webpackType;
+      })).rspack as typeof webpackType;
     } else {
       throw new Error(
-        `[ember-auto-import] this version of ember-auto-import requires the app to have a dependency on webpack 5`
+        `[ember-auto-import] this version of ember-auto-import requires the app to have a dependency on @rspack/core ^1.2.7`
       );
     }
 

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -110,7 +110,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
     super(priorTrees, {
       persistentOutput: true,
       needsCache: true,
-      annotation: 'ember-auto-import-webpack',
+      annotation: 'ember-auto-import-rspack',
     });
     this.previousFileState = new Map();
   }


### PR DESCRIPTION
This PR lets ember-auto-import `require` `@rspack/core` instead of `webpack` for better build speed.

This PR also replaces `mini-css-extract-plugin` with `rspack.CssExtractRspackPlugin` as documented [here](https://rspack.dev/guide/migration/webpack#mini-css-extract-plugin).